### PR TITLE
Add login information after logo

### DIFF
--- a/app/overrides/decidim/devise/shared/_omniauth_buttons/add_gmail_login_info.html.erb.deface
+++ b/app/overrides/decidim/devise/shared/_omniauth_buttons/add_gmail_login_info.html.erb.deface
@@ -1,0 +1,3 @@
+<!-- insert_before ".login__omniauth-separator" -->
+
+ <div class="login__info mt-2 flex justify-center font-semibold"><%= t("decidim.devise.registrations.new.sign_up_also_with") %></div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,2 +1,7 @@
 ---
 en:
+  decidim:
+    devise:
+      registrations:
+        new:
+          sign_up_also_with: Sign up with your gmail account

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,2 +1,7 @@
 ---
 es:
+  decidim:
+    devise:
+      registrations:
+        new:
+          sign_up_also_with: Entra con tu cuenta de gmail

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -1,2 +1,7 @@
 ---
 eu:
+  decidim:
+    devise:
+      registrations:
+        new:
+          sign_up_also_with: Erabili zure gmail kontua sartzeko

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1805,8 +1805,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_094741) do
     t.jsonb "body"
     t.integer "comments_count", default: 0, null: false
     t.integer "follows_count", default: 0, null: false
-    t.integer "evaluation_assignments_count", default: 0
     t.integer "old_state", default: 0, null: false
+    t.integer "evaluation_assignments_count", default: 0
     t.datetime "withdrawn_at", precision: nil
     t.integer "decidim_proposals_proposal_state_id"
     t.datetime "deleted_at"

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -9,7 +9,8 @@ checksums = [
   {
     package: "decidim-core",
     files: {
-      "/app/views/layouts/decidim/header/_main.html.erb" => "a090eeca739613446d2eab8f4de513b1"
+      "/app/views/layouts/decidim/header/_main.html.erb" => "a090eeca739613446d2eab8f4de513b1",
+      "/app/views/decidim/devise/shared/_omniauth_buttons.html.erb" => "688a13e36af349a91e37b04c6caaa3a9"
     }
   }
 ]


### PR DESCRIPTION
🎩 What? Why?
Add the text "Sign up with your Gmail account" after the logo.

📌 Related Issues
Link your PR to an issue
Related to #?
Fixes #?

📷 Screenshots
<img width="1174" height="799" alt="image" src="https://github.com/user-attachments/assets/9a007415-4335-4bac-9911-fc98a860fbe2" />
login view

♥️ Thank you!